### PR TITLE
SampleImageUploader: show dialog when upload done

### DIFF
--- a/src/main/java/net/imagej/plugins/commands/upload/SampleImageUploader.java
+++ b/src/main/java/net/imagej/plugins/commands/upload/SampleImageUploader.java
@@ -107,9 +107,13 @@ public class SampleImageUploader implements Command {
 		}
 		try {
 			uploadFile(sampleImage);
+			ui.showDialog("Finished uploading file: " + sampleImage,
+				"Upload complete!");
 		}
 		catch (Exception e) {
 			log.error(e);
+			ui.showDialog("There was a problem uploading file: " + sampleImage +
+				"\nSee the log for details.", "Upload failed");
 		}
 	}
 


### PR DESCRIPTION
This may be a stopgap solution until we have a better TaskService in
place (https://github.com/imagej/imagej/issues/25). But until that time,
it is nice to show a clear dialog box upon either success _or_ failure.

We show the box only in the run() method itself, so that other potential
uses of the API are not infected with calls to the UIService.

Fixes issue #7.
